### PR TITLE
Implement file downloader

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -383,7 +383,7 @@
 
 /* ------------------------------------------ */
 
-.loadAssignsDiv {
+.lastRowDiv {
   display: flex;
   flex-direction: row;
   gap: 3.84px;

--- a/CSS/style.css
+++ b/CSS/style.css
@@ -383,13 +383,13 @@
 
 /* ------------------------------------------ */
 
-.loadAssignsForm {
+.loadAssignsDiv {
   display: flex;
   flex-direction: row;
   gap: 3.84px;
 }
 
-.loadAssignsBtn {
+.loadAssignsBtn, .downloadBtn {
   padding: 6.4px 9.6px;
 
   background-color: #e1e2e1;
@@ -504,6 +504,7 @@
 .sortDate:hover,
 .addTodoBtn:hover,
 .loadAssignsBtn:hover,
+.downloadBtn:hover,
 .AssignLink:hover,
 .colorPickerBtn:hover,
 .changeTodoBtn_O:hover {

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 <li>이제 해당 시간이 되면 자동으로 Collaborate에 접속하게 될 것입니다. (단, 브라우저가 실행 중이고, 블랙보드에 로그인이 되어있을 때)</li>
 </ul>
 
-### 4. 강의 슬라이드 일괄 다운로드
+### 4. 강의 슬라이드 Downloader
 <ul>
 <li>학기 말에 모든 강의 슬라이드를 백업할 수 있는 기능입니다.</li>
 <ol>
@@ -57,7 +57,7 @@
 
 # Contributors
 ### Blackboard Extension 팀 구성원
-<p><a href="https://github.com/See-Y">장영웅</a>, <a href="https://github.com/shfd27">김기현</a>, <a href="https://github.com/calculus0129">방재현</a>, <a href="https://github.com/123wwwa">서휘원</a>, <a href="https://github.com/hikari0102">이예승</a>, <a href="https://github.com/bini-Bin">조성빈</a></p>
+<p><a href="https://github.com/See-Y">장영웅</a>, <a href="https://github.com/shfd27">김기현</a>, <a href="https://github.com/calculus0129">방재현</a>, <a href="https://github.com/123wwwa">서휘원</a>, <a href="https://github.com/hikari0102">이예승</a>, <a href="https://github.com/bini-Bin">조성빈</a></p>, <a href="https://github.com/junwha0511">홍준화</a></p>
 
 ### 자동 로그인 구현
 <p>Contributor: 서휘원</p>
@@ -67,6 +67,9 @@
 
 ### Collaborate 예약
 <p>Contributor: 서휘원, 김기현, 이예승</p>
+
+### 강의 슬라이드 Downloader
+<p> Contributor: 홍준화 </p>
 
 <!--Contributor에서 이름이 가장 앞에 있는 사람이 가장 많은 기여를 했습니다-->
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 <p>Contributor: 서휘원, 김기현, 이예승</p>
 
 ### 강의 슬라이드 Downloader
-<p> Contributor: 홍준화 </p>
+<p> Contributor: 홍준화, 장영웅 </p>
 
 <!--Contributor에서 이름이 가장 앞에 있는 사람이 가장 많은 기여를 했습니다-->
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@
 <li>이제 해당 시간이 되면 자동으로 Collaborate에 접속하게 될 것입니다. (단, 브라우저가 실행 중이고, 블랙보드에 로그인이 되어있을 때)</li>
 </ul>
 
+### 4. 강의 슬라이드 일괄 다운로드
+<ul>
+<li>학기 말에 모든 강의 슬라이드를 백업할 수 있는 기능입니다.</li>
+<ol>
+  <li>강의 슬라이드 게시판으로 이동합니다 (contents, slides, etc. </li>
+  <li>오른쪽 아래의 헥사 로고를 클릭합니다.</li>
+  <img src="https://user-images.githubusercontent.com/17183234/208171255-a3d4f165-4837-41bb-99bd-2adeb0320bb7.png" width=700>
+  <li>다운로드 버튼을 누르면 모든 강의 슬라이드가 일괄 다운로드 됩니다.</li>
+  <img width="1380" alt="image" src="https://user-images.githubusercontent.com/17183234/208171445-2926b805-b59f-4629-926a-df5b516d9cb1.png">
+</ol>
+</ul>
+
 # Contributors
 ### Blackboard Extension 팀 구성원
 <p><a href="https://github.com/See-Y">장영웅</a>, <a href="https://github.com/shfd27">김기현</a>, <a href="https://github.com/calculus0129">방재현</a>, <a href="https://github.com/123wwwa">서휘원</a>, <a href="https://github.com/hikari0102">이예승</a>, <a href="https://github.com/bini-Bin">조성빈</a></p>

--- a/Scripts/Downloader/downloader.js
+++ b/Scripts/Downloader/downloader.js
@@ -1,29 +1,66 @@
 var lastRowDiv = document.getElementsByClassName("lastRowDiv")[0];
+const BB_PREFIX_URL = "https://blackboard.unist.ac.kr";
+const MAX_NEST_THRESHOLD = 5;
 
-function downloads(doc){
-    const bbPrefixUrl = "https://blackboard.unist.ac.kr/";
+const decodeReaderStream = (rb) => {
+    const reader = rb.getReader();
+    return new ReadableStream({
+      start(controller) {
+        function push() {
+          reader.read().then(({ done, value }) => {
+            if (done) {
+              controller.close();
+              return;
+            }
+            controller.enqueue(value);
+            push();
+          });
+        }
+        push();
+      },
+    });
+}
+
+const getRedirectedResult = (originUrl, callback) => fetch(originUrl, {
+    headers: {"Host": BB_PREFIX_URL}
+    })
+    .then((res)=>(res.body)).then((rb)=>decodeReaderStream(rb))
+    .then((stream) =>
+    new Response(stream, { headers: { 'Content-Type': 'text/html' } }).text() 
+    )
+    .then((result) => {
+    callback(result);
+});
+
+function download(doc, count){
+    console.log(doc);
+    if (count == MAX_NEST_THRESHOLD) return;
     var content = doc.getElementById("content_listContainer");
     if (!isNaN(content)) return;
 
     var aTags = content.getElementsByTagName("a");
     for (var a of aTags) {
         var link = a.getAttribute("href");
-        if(link == "#contextMenu") continue;
-        var tag = a.getAttribute("onclick");
-        var target = a.getAttribute("target");
-        if(isNaN(tag) || isNaN(target)){
-            var fileUrl = bbPrefixUrl+link;
-            chrome.runtime.sendMessage({sender: "downloader", url: fileUrl});
-            console.log(fileUrl);
+        const buttonRe = "^#.*"
+        if(link.match(buttonRe)) continue; // not a link
+        
+        const contentRe = new RegExp("^\/webapps\/blackboard.*"); // not file, loadable webapp
+        const result = link.match(contentRe);
+        
+        if(result){ // webapp (recursive)
+            getRedirectedResult(link, (res)=>{ // Redirect to webapp
+                var folder_doc = document.implementation.createHTMLDocument('');
+                folder_doc.write(res);
+                download(folder_doc, count+1);
+                folder_doc.close();
+                }
+            );
         }
-        else{
-            folder = window.open(bbPrefixUrl+link);
-            downloads(folder.document);
-            folder.close();
+        else{ // url (download)
+            chrome.runtime.sendMessage({sender: "downloader", url: link});
         }
     }
 }
-
 
 var downloadBtn = HTMLAppender({
     parent: lastRowDiv,
@@ -33,7 +70,7 @@ var downloadBtn = HTMLAppender({
     innerText: "Download All",
     eventListener:  {
         click: (evt) => {
-            downloads(document);
+            download(document, 0);
         }
     }
 });

--- a/Scripts/Downloader/downloader.js
+++ b/Scripts/Downloader/downloader.js
@@ -1,8 +1,8 @@
 const bbPrefixUrl = "https://blackboard.unist.ac.kr/"
-var loadAssignsDiv = document.getElementsByClassName("loadAssignsDiv")[0];
+var lastRowDiv = document.getElementsByClassName("lastRowDiv")[0];
 
 var downloadBtn = HTMLAppender({
-    parent: loadAssignsDiv,
+    parent: lastRowDiv,
     tagName: "button",
     className: "downloadBtn",
     type: "button",

--- a/Scripts/Downloader/downloader.js
+++ b/Scripts/Downloader/downloader.js
@@ -1,5 +1,29 @@
-const bbPrefixUrl = "https://blackboard.unist.ac.kr/"
 var lastRowDiv = document.getElementsByClassName("lastRowDiv")[0];
+
+function downloads(doc){
+    const bbPrefixUrl = "https://blackboard.unist.ac.kr/";
+    var content = doc.getElementById("content_listContainer");
+    if (!isNaN(content)) return;
+
+    var aTags = content.getElementsByTagName("a");
+    for (var a of aTags) {
+        var link = a.getAttribute("href");
+        if(link == "#contextMenu") continue;
+        var tag = a.getAttribute("onclick");
+        var target = a.getAttribute("target");
+        if(isNaN(tag) || isNaN(target)){
+            var fileUrl = bbPrefixUrl+link;
+            chrome.runtime.sendMessage({sender: "downloader", url: fileUrl});
+            console.log(fileUrl);
+        }
+        else{
+            folder = window.open(bbPrefixUrl+link);
+            downloads(folder.document);
+            folder.close();
+        }
+    }
+}
+
 
 var downloadBtn = HTMLAppender({
     parent: lastRowDiv,
@@ -9,12 +33,7 @@ var downloadBtn = HTMLAppender({
     innerText: "Download All",
     eventListener:  {
         click: (evt) => {
-            var content = document.getElementById("content_listContainer");
-            if (!isNaN(content)) return;
-            var aTags = content.getElementsByTagName("a");
-            for (var a of aTags) {
-                var fileUrl = bbPrefixUrl+a.getAttribute("href");
-                chrome.runtime.sendMessage({sender: "downloader", url: fileUrl});            }
+            downloads(document);
         }
     }
 });

--- a/Scripts/Downloader/downloader.js
+++ b/Scripts/Downloader/downloader.js
@@ -1,0 +1,20 @@
+const bbPrefixUrl = "https://blackboard.unist.ac.kr/"
+var loadAssignsDiv = document.getElementsByClassName("loadAssignsDiv")[0];
+
+var downloadBtn = HTMLAppender({
+    parent: loadAssignsDiv,
+    tagName: "button",
+    className: "downloadBtn",
+    type: "button",
+    innerText: "Download All",
+    eventListener:  {
+        click: (evt) => {
+            var content = document.getElementById("content_listContainer");
+            if (!isNaN(content)) return;
+            var aTags = content.getElementsByTagName("a");
+            for (var a of aTags) {
+                var fileUrl = bbPrefixUrl+a.getAttribute("href");
+                chrome.runtime.sendMessage({sender: "downloader", url: fileUrl});            }
+        }
+    }
+});

--- a/Scripts/ToDo/btn.js
+++ b/Scripts/ToDo/btn.js
@@ -289,14 +289,14 @@ const initializeUI = () => {
     innerText: "Add",
   });
 
-  var loadAssignsDiv = HTMLAppender({
+  var lastRowDiv = HTMLAppender({
     parent: popupDiv,
     tagName: "div",
-    className: "loadAssignsDiv",
+    className: "lastRowDiv",
   });
 
   var loadAssignsForm = HTMLAppender({
-    parent: loadAssignsDiv,
+    parent: lastRowDiv,
     tagName: "form",
     id: "loadAssignsForm",
     className: "loadAssignsForm",

--- a/background.js
+++ b/background.js
@@ -19,3 +19,9 @@ chrome.alarms.onAlarm.addListener(function(alarm) {
     gotoCollaborate(alarm.name.split(":")[0]);
 });
 chrome.alarms.getAll(function(alarms) { console.log(alarms); })
+
+chrome.runtime.onMessage.addListener(
+    function(request, sender, sendResponse) {
+        if (request.sender === "downloader") chrome.downloads.download({url: request.url});
+    }
+);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Blackboard Extension",
   "description": "Blackboard Extension from UNIST HeXA",
-  "version": "2.02",
+  "version": "2.03",
   "manifest_version": 3,
   "action": {
       "default_icon": "Images/HeXA_icon.png",

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
       "service_worker": "background.js",
       "type": "module"
   },
-  "permissions": ["storage", "alarms"],
+  "permissions": ["storage", "alarms", "downloads"],
   
   "host_permissions": ["<all_urls>"],
   "content_security_policy": {
@@ -79,6 +79,10 @@
       "matches": ["https://blackboard.unist.ac.kr/*"],
       "js": ["Scripts/ToDo/btn.js"],
       "css": ["CSS/style.css"]
+    },
+    {
+      "matches": ["https://blackboard.unist.ac.kr/webapps/blackboard/content/*"],
+      "js": ["Scripts/Downloader/downloader.js"]
     },
     {
       "matches": ["https://au-lti.bbcollab.com/*"],


### PR DESCRIPTION
BB 유저들이 학기말에 모든 강의 슬라이드를 한 번에 백업할 수 있도록 도와주는 기능입니다.
- 슬라이드 및 컨텐츠 게시판(content board)에서만 다운로더 버튼이 나타나도록 구현하였습니다.
- chrome.downloads API를 활용하였고, 이 과정에서 Permission이 추가되었습니다
- 기존 ToDo에서 만드신 FloatingDiv 내부에 추가 삽입을 하도록 구현하였습니다.
- Message passing을 통해 downloader.js에서 파싱한 URL을 background.js가 다운로드하는 방식입니다.
- 현재 ToDo로 명명되어 있는 스크립트 set의 경우 추후 다양한 방안으로 활용이 가능하므로 재명명 및 모듈화를 제안드립니다. (이 PR에는 반영되지 않았습니다)

<img width="752" alt="image" src="https://user-images.githubusercontent.com/17183234/208168519-1ab3d998-2f0d-46b2-b3a0-e9d03d0189ae.png">
